### PR TITLE
Responsive for tablets and mobiles

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -421,3 +421,39 @@ ul.contributor-name li a {
 li.dev-name::marker {
   color: #007acc;
 }
+
+/*Media Query*/
+/*Responsive for tablets <770px*/
+@media screen and (max-width: 770px){
+  img.cardimg {
+    width: 45px;
+    height: auto;
+  }
+
+  .opponentcards::after{
+    content: "";
+    position: absolute;
+    background-image: url("../assets/imgs/back-cover/back-cover.png") !important;
+    top: 0;
+    left: 0;
+    z-index: 5;
+      width: 100%;
+    height: 100%;
+    background-size: 45px 69px;
+    background-repeat: repeat-x; /* Repeat horizontally */
+  }
+  .opponentcards{
+    width: 315px;
+  }
+}
+/*Responsive for mobile <435px to 290px*/
+@media screen and (max-width: 435px){
+  .score-container {
+    display: flex;
+    position: absolute;
+    top: 10%;
+    left: 0;
+    justify-content: space-between;
+    padding-inline: 20px
+  }
+}


### PR DESCRIPTION
For tablets below 770px, not the behavior of both opponent and player cards is as expected. For mobiles below 435px, the score is now visible at the top for clear view. Since there are very few smaller devices below 290px, the game now only supports devices above 290px.